### PR TITLE
Feature: Pass extra arguments to Movie in watchlist_movies

### DIFF
--- a/trakt/users.py
+++ b/trakt/users.py
@@ -337,6 +337,7 @@ class User:
             self._movie_watchlist = []
             for movie in data:
                 mov = movie.pop('movie')
+                mov.update(movie)
                 self._movie_watchlist.append(Movie(**mov))
             yield self._movie_watchlist
         yield self._movie_watchlist


### PR DESCRIPTION
A simple fix to have watchlist_movies to add extra fields like `listed_at`:
- https://github.com/Taxel/PlexTraktSync/issues/1247#issuecomment-1369191415

watchlist_shows already does this:
- https://github.com/glensc/python-pytrakt/blob/143344b298d6c079cb4393eb92d02d376cfcf3fe/trakt/users.py#L323