### PR TITLE
Fix: use builtin dataclasses.fields instead of __annotations__

### DIFF
--- a/trakt/config.py
+++ b/trakt/config.py
@@ -3,7 +3,7 @@
 __author__ = 'Elan Ruusamäe'
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from os.path import exists
 from typing import Optional
 
@@ -40,7 +40,8 @@ class AuthConfig:
 
     def all(self):
         result = {}
-        for key in self.__annotations__.keys():
+        for field in fields(self):
+            key = field.name
             result[key] = self.get(key)
 
         return result
@@ -55,7 +56,8 @@ class AuthConfig:
         with open(self.config_path) as config_file:
             config_data = json.load(config_file)
 
-        for key in self.__annotations__.keys():
+        for field in fields(self):
+            key = field.name
             # Don't overwrite
             if self.get(key) is not None:
                 continue


### PR DESCRIPTION
in python3.14, computing the `__annotations__` is done lazily which
leads to an error. see
https://docs.python.org/3/whatsnew/3.14.html#implications-for-readers-of-annotations
