### PR TITLE
Feature: Add message to OAuthRefreshException

### DIFF
--- a/trakt/errors.py
+++ b/trakt/errors.py
@@ -69,6 +69,8 @@ class OAuthException(TraktException):
 
 
 class OAuthRefreshException(OAuthException):
+    message = 'Unauthorized - OAuth token refresh failed'
+
     def __init__(self, response=None):
         super().__init__(response)
         self.data = self.response.json()


### PR DESCRIPTION
This sets own message rather inheriting from `OAuthException`

Extracted from https://github.com/glensc/python-pytrakt/pull/104