### PR TITLE
Feature: Add __str__ to OAuthRefreshException

### DIFF
--- a/trakt/errors.py
+++ b/trakt/errors.py
@@ -109,6 +109,14 @@ class OAuthRefreshException(OAuthException):
 
         return data
 
+    def __str__(self):
+        if self.error and self.error_description:
+            return f'{self.message}: {self.error} - {self.error_description}'
+
+        if self.error:
+            return f'{self.message}: {self.error}'
+
+        return self.message
 
 class ForbiddenException(TraktException):
     """TraktException type to be raised when a 403 return code is received"""


### PR DESCRIPTION
_Extracted from https://github.com/glensc/python-pytrakt/pull/104_


Adds a `__str__` method to `OAuthRefreshException` so stringifying the exception produces a more descriptive message that includes the error and error_description fields from the OAuth response when available, falling back to the inherited message.

Changes:

- Implement `__str__` on `OAuthRefreshException` with three formatting branches (both fields, error only, message only).
