### PR TITLE
Fix: Safely parse OAuth refresh error responses

### DIFF
--- a/trakt/errors.py
+++ b/trakt/errors.py
@@ -69,7 +69,7 @@ class OAuthException(TraktException):
 
 
 class OAuthRefreshException(OAuthException):
-    """TraktException type to be raised when OAuth token refresh fails"""
+    """Raised when OAuth token refresh fails."""
 
     message = 'Unauthorized - OAuth token refresh failed'
 

--- a/trakt/errors.py
+++ b/trakt/errors.py
@@ -69,6 +69,8 @@ class OAuthException(TraktException):
 
 
 class OAuthRefreshException(OAuthException):
+    """TraktException type to be raised when OAuth token refresh fails"""
+
     message = 'Unauthorized - OAuth token refresh failed'
 
     def __init__(self, response=None):

--- a/trakt/errors.py
+++ b/trakt/errors.py
@@ -73,7 +73,7 @@ class OAuthRefreshException(OAuthException):
 
     def __init__(self, response=None):
         super().__init__(response)
-        self.data = self.response.json()
+        self.data = self._error_data(self.response)
 
     @property
     def error(self):
@@ -82,6 +82,30 @@ class OAuthRefreshException(OAuthException):
     @property
     def error_description(self):
         return self.data["error_description"]
+
+    @classmethod
+    def _error_data(cls, response):
+        data = cls._response_json(response)
+
+        return {
+            "error": data.get("error", ""),
+            "error_description": data.get("error_description", ""),
+        }
+
+    @staticmethod
+    def _response_json(response):
+        if response is None:
+            return {}
+
+        try:
+            data = response.json()
+        except (ValueError, AttributeError):
+            return {}
+
+        if not isinstance(data, dict):
+            return {}
+
+        return data
 
 
 class ForbiddenException(TraktException):


### PR DESCRIPTION
Extracted from https://github.com/glensc/python-pytrakt/pull/104