### PR TITLE
Fix: Ignore unknown API fields when building ListEntry

### DIFF
--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -2,7 +2,7 @@
 from trakt.movies import Movie
 from trakt.people import Person
 from trakt.tv import TVEpisode, TVSeason, TVShow
-from trakt.users import (Request, User, UserList, get_all_requests,
+from trakt.users import (PublicList, Request, User, UserList, get_all_requests,
                          get_user_settings)
 
 
@@ -141,3 +141,19 @@ def test_liked_lists():
 
     lists = sean.get_liked_lists('comments')
     assert isinstance(lists, list)
+
+
+def test_process_items_ignores_unknown_fields():
+    items = [{
+        'rank': 1,
+        'id': 101,
+        'listed_at': '2024-01-01T00:00:00.000Z',
+        'type': 'movie',
+        'my_rating': 8,
+        'movie': {'title': 'TRON', 'year': 1982,
+                  'ids': {'trakt': 1, 'slug': 'tron'}},
+    }]
+    entries = list(PublicList._process_items(items))
+    assert len(entries) == 1
+    assert entries[0].id == 101
+    assert entries[0].data['title'] == 'TRON'

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Interfaces to all of the User objects offered by the Trakt.tv API"""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import Any, NamedTuple, Optional, Union
 
 from trakt.core import delete, get, post
@@ -182,13 +182,17 @@ class PublicList(DataClassMixin(ListDescription), IdsMixin):
 
     @staticmethod
     def _process_items(items):
+        entry_fields = {f.name for f in fields(ListEntry)}
         for item in items:
             if "type" not in item:
                 continue
             data = item.pop(item["type"])
             if "show" in item:
                 data["show"] = item.pop("show")
-            yield ListEntry(**item, data=data)
+            # Drop any fields the API returns that ListEntry does not declare
+            # (e.g. "my_rating") so they don't break construction.
+            kwargs = {k: v for k, v in item.items() if k in entry_fields}
+            yield ListEntry(**kwargs, data=data)
 
 
 class UserList(DataClassMixin(ListDescription), IdsMixin):


### PR DESCRIPTION
Trakt's list-items endpoint now returns a `my_rating` field on each item. `ListEntry` is a frozen dataclass with a fixed set of fields, so `ListEntry(**item, data=data)` raises `TypeError: ListEntry.__init__() got an unexpected keyword argument 'my_rating'`, which breaks loading the whole list.

This filters `item` down to the fields `ListEntry` actually declares before constructing it, so unknown fields the API adds are ignored rather than crashing. Added a regression test in `tests/test_users.py`.

Fixes #111
