### PR TITLE
Cleanup: Remove get_watched deprecation

### DIFF
--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -454,8 +454,6 @@ def get_watchlist(list_type=None, sort=None):
     yield results
 
 
-@deprecated("This method returns watchlist, not watched list. "
-            "This will be fixed in PyTrakt 4.x to return watched list")
 @get
 def get_watched(list_type=None, extended=None):
     """Return all movies or shows a user has watched sorted by most plays.

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -6,8 +6,6 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
-from deprecated import deprecated
-
 from trakt.core import delete, get, post
 from trakt.mixins import IdsMixin
 from trakt.utils import build_uri, slugify, timestamp


### PR DESCRIPTION
This has been changed in 7118e50

This was released in 3.4.9.

Refs
- https://github.com/moogar0880/PyTrakt/pull/204

cc @simonc56 