### PR TITLE
Refactor: Add standalone paginate helper

### DIFF
--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,5 +1,4 @@
 from trakt.pagination import paginate
-from trakt.api import HttpClient
 
 
 class FakeClient:
@@ -72,17 +71,3 @@ def test_paginate_skips_none_extends_lists_and_appends_objects():
     result = paginate('movies/popular', api=client)
 
     assert result == [{'title': 'Two'}, {'title': 'Three'}]
-
-
-def test_http_client_paginate_delegates(monkeypatch):
-    def fake_paginate(url, api, **params):
-        assert isinstance(api, HttpClient)
-        assert url == 'movies/popular'
-        assert params == {'limit': 2}
-        return ['ok']
-
-    monkeypatch.setattr('trakt.api.paginate', fake_paginate)
-
-    client = HttpClient('https://api.trakt.tv/', session=None)
-
-    assert client.paginate('movies/popular', limit=2) == ['ok']

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,88 @@
+from trakt.pagination import paginate
+from trakt.api import HttpClient
+
+
+class FakeClient:
+    def __init__(self, pages):
+        self.pages = list(pages)
+        self.urls = []
+
+    def get(self, url, include_headers=False):
+        self.urls.append((url, include_headers))
+        return self.pages.pop(0)
+
+
+def test_paginate_fetches_all_list_pages():
+    client = FakeClient([
+        ([{'title': 'One'}], {'X-Pagination-Page-Count': '3'}),
+        ([{'title': 'Two'}], {'X-Pagination-Page-Count': '3'}),
+        ([{'title': 'Three'}], {'X-Pagination-Page-Count': '3'}),
+    ])
+
+    result = paginate(
+        'users/{user}/watched/movies',
+        api=client,
+        user='sean',
+        limit=2,
+    )
+
+    assert result == [
+        {'title': 'One'},
+        {'title': 'Two'},
+        {'title': 'Three'},
+    ]
+    assert client.urls == [
+        ('users/sean/watched/movies?limit=2', True),
+        ('users/sean/watched/movies?page=2&limit=2', True),
+        ('users/sean/watched/movies?page=3&limit=2', True),
+    ]
+
+
+def test_paginate_stops_after_one_page_without_valid_page_count():
+    client = FakeClient([
+        ([{'title': 'One'}], {'X-Pagination-Page-Count': 'invalid'}),
+        ([{'title': 'Two'}], {'X-Pagination-Page-Count': '2'}),
+    ])
+
+    result = paginate('movies/popular', api=client)
+
+    assert result == [{'title': 'One'}]
+    assert client.urls == [('movies/popular', True)]
+
+
+def test_paginate_stops_after_one_page_without_page_count():
+    client = FakeClient([
+        ([{'title': 'One'}], {}),
+        ([{'title': 'Two'}], {'X-Pagination-Page-Count': '2'}),
+    ])
+
+    result = paginate('movies/popular', api=client)
+
+    assert result == [{'title': 'One'}]
+    assert client.urls == [('movies/popular', True)]
+
+
+def test_paginate_skips_none_extends_lists_and_appends_objects():
+    client = FakeClient([
+        (None, {'X-Pagination-Page-Count': '3'}),
+        ([{'title': 'Two'}], {'X-Pagination-Page-Count': '3'}),
+        ({'title': 'Three'}, {'X-Pagination-Page-Count': '3'}),
+    ])
+
+    result = paginate('movies/popular', api=client)
+
+    assert result == [{'title': 'Two'}, {'title': 'Three'}]
+
+
+def test_http_client_paginate_delegates(monkeypatch):
+    def fake_paginate(url, api, **params):
+        assert isinstance(api, HttpClient)
+        assert url == 'movies/popular'
+        assert params == {'limit': 2}
+        return ['ok']
+
+    monkeypatch.setattr('trakt.api.paginate', fake_paginate)
+
+    client = HttpClient('https://api.trakt.tv/', session=None)
+
+    assert client.paginate('movies/popular', limit=2) == ['ok']

--- a/trakt/api.py
+++ b/trakt/api.py
@@ -7,12 +7,11 @@ from json import JSONDecodeError
 from requests import Session
 from requests.auth import AuthBase
 
-from trakt import errors
+from trakt import errors, pagination
 from trakt.config import AuthConfig
 from trakt.core import TIMEOUT
 from trakt.errors import (BadRequestException, BadResponseException,
                           OAuthException, OAuthRefreshException)
-from trakt.utils import build_uri
 
 __author__ = 'Elan Ruusamäe'
 
@@ -80,34 +79,9 @@ class HttpClient:
         """
         return self.request('put', url, data=data)
 
-    def iter_pages(self, url, **params):
-        """Yield successive pages for a paginated GET endpoint."""
-        page = 1
-        while True:
-            page_url = build_uri(url, **params) if page == 1 else build_uri(
-                url, page=page, **params
-            )
-            page_data, headers = self.get(page_url, include_headers=True)
-            yield page_data
-            try:
-                page_count = int(headers.get('X-Pagination-Page-Count', 1))
-            except (TypeError, ValueError):
-                page_count = 1
-            if page >= page_count:
-                break
-            page += 1
-
     def paginate(self, url, **params):
         """Return a flattened list from all pages of a paginated GET endpoint."""
-        results = []
-        for page_data in self.iter_pages(url, **params):
-            if page_data is None:
-                continue
-            if isinstance(page_data, list):
-                results.extend(page_data)
-            else:
-                results.append(page_data)
-        return results
+        return pagination.paginate(self, url, **params)
 
     @property
     def auth(self):

--- a/trakt/api.py
+++ b/trakt/api.py
@@ -81,7 +81,7 @@ class HttpClient:
 
     def paginate(self, url, **params):
         """Return a flattened list from all pages of a paginated GET endpoint."""
-        return pagination.paginate(self, url, **params)
+        return pagination.paginate(url, api=self, **params)
 
     @property
     def auth(self):

--- a/trakt/api.py
+++ b/trakt/api.py
@@ -7,7 +7,7 @@ from json import JSONDecodeError
 from requests import Session
 from requests.auth import AuthBase
 
-from trakt import errors, pagination
+from trakt import errors
 from trakt.config import AuthConfig
 from trakt.core import TIMEOUT
 from trakt.errors import (BadRequestException, BadResponseException,
@@ -78,10 +78,6 @@ class HttpClient:
             Various exceptions from `raise_if_needed` based on HTTP response status.
         """
         return self.request('put', url, data=data)
-
-    def paginate(self, url, **params):
-        """Return a flattened list from all pages of a paginated GET endpoint."""
-        return pagination.paginate(url, api=self, **params)
 
     @property
     def auth(self):

--- a/trakt/pagination.py
+++ b/trakt/pagination.py
@@ -1,0 +1,41 @@
+"""Pagination helpers for Trakt API clients."""
+
+from trakt.utils import build_uri
+
+__author__ = 'Elan Ruusamäe'
+__all__ = ['paginate']
+
+
+def page_count(headers):
+    try:
+        return int(headers.get('X-Pagination-Page-Count', 1))
+    except (TypeError, ValueError):
+        return 1
+
+
+def iter_pages(client, url: str, **params):
+    """Yield successive pages for a paginated GET endpoint."""
+    page = 1
+    while True:
+        page_url = build_uri(url, **params) if page == 1 else build_uri(
+            url, page=page, **params
+        )
+        page_data, headers = client.get(page_url, include_headers=True)
+        yield page_data
+
+        if page >= page_count(headers):
+            break
+        page += 1
+
+
+def paginate(client, url: str, **params):
+    """Return a flattened list from all pages of a paginated GET endpoint."""
+    results = []
+    for page_data in iter_pages(client, url, **params):
+        if page_data is None:
+            continue
+        if isinstance(page_data, list):
+            results.extend(page_data)
+        else:
+            results.append(page_data)
+    return results

--- a/trakt/pagination.py
+++ b/trakt/pagination.py
@@ -16,6 +16,7 @@ def page_count(headers):
 
 def iter_pages(client, url: str, **params):
     """Yield successive pages for a paginated GET endpoint."""
+    params.pop('page', None)
     page = 1
     while True:
         page_url = build_uri(url, **params) if page == 1 else build_uri(

--- a/trakt/pagination.py
+++ b/trakt/pagination.py
@@ -1,5 +1,6 @@
 """Pagination helpers for Trakt API clients."""
 
+from trakt.core import api as factory
 from trakt.utils import build_uri
 
 __author__ = 'Elan Ruusamäe'
@@ -28,9 +29,10 @@ def iter_pages(client, url: str, **params):
         page += 1
 
 
-def paginate(client, url: str, **params):
+def paginate(url: str, api=None, **params):
     """Return a flattened list from all pages of a paginated GET endpoint."""
     results = []
+    client = api or factory()
     for page_data in iter_pages(client, url, **params):
         if page_data is None:
             continue

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -4,9 +4,10 @@
 from dataclasses import dataclass, fields
 from typing import Any, NamedTuple, Optional, Union
 
-from trakt.core import api, delete, get, post
+from trakt.core import delete, get, post
 from trakt.mixins import DataClassMixin, IdsMixin
 from trakt.movies import Movie
+from trakt.pagination import paginate
 from trakt.people import Person
 from trakt.tv import TVEpisode, TVSeason, TVShow
 from trakt.utils import build_uri, slugify
@@ -548,8 +549,7 @@ class User:
         collection. Automatically fetches all pages.
         """
         if self._watched_movies is None:
-            client = api()
-            all_movies = client.paginate(
+            all_movies = paginate(
                 'users/{user}/watched/movies',
                 user=slugify(self.username),
             )


### PR DESCRIPTION
Introduce a standalone helper for iterating over paginated API responses and flatten page data.

## **Walkthrough**

Pagination logic is extracted from `HttpClient` in `trakt/api.py` into a new standalone module `trakt/pagination.py` providing `paginate`, `iter_pages`, and `page_count` functions. `trakt/users.py` is updated to call the new `paginate` function directly. New tests validate pagination behavior with a `FakeClient` test double.

### **Changes**

**Pagination module extraction**

| **Layer / File(s)** | **Summary** |
|---------------------|-------------|
| **New pagination module**<br>`trakt/pagination.py` | Adds `page_count`, `iter_pages`, and `paginate` functions to fetch and flatten paginated results based on the `X-Pagination-Page-Count` header. |
| **HttpClient cleanup**<br>`trakt/api.py` | Removes `iter_pages` and `paginate` methods from `HttpClient` and updates imports to reference the new `pagination` module. |
| **Users module wiring**<br>`trakt/users.py` | Imports `paginate` from `trakt.pagination` and updates `User.watched_movies` to call it directly instead of `api().paginate(...)`. |
| **Pagination tests**<br>`tests/test_pagination.py` | Adds `FakeClient` and tests covering multi-page fetching, invalid/missing page-count handling, and None/list/non-list aggregation behavior. |

