### PR TITLE
Fix: Reorder extended= param to be first

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -73,7 +73,7 @@ def test_build_uri():
     assert build_uri('shows/popular', extended='full') == \
         'shows/popular?extended=full'
     assert build_uri('shows/popular', page=2, extended='full') == \
-        'shows/popular?page=2&extended=full'
+        'shows/popular?extended=full&page=2'
     assert build_uri('shows/popular?sort=rank', page=2) == \
         'shows/popular?sort=rank&page=2'
 

--- a/trakt/utils.py
+++ b/trakt/utils.py
@@ -101,12 +101,12 @@ def build_uri(uri, page=None, limit=None, extended=None, **params):
     uri = uri.format(**params)
 
     query = []
+    if extended:
+        query.append(('extended', extended))
     if page is not None:
         query.append(('page', _validate_pagination_param('page', page)))
     if limit is not None:
         query.append(('limit', _validate_pagination_param('limit', limit)))
-    if extended:
-        query.append(('extended', extended))
 
     if query:
         uri += ('&' if '?' in uri else '?') + urlencode(query)


### PR DESCRIPTION
Actually, just re-order paging params to be last

This is to keep backward compatible to be able to use url based cache rules with requests-cache.