### PR TITLE
Feature: Disable coderabbit auto-review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,1 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,1 +1,4 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  auto_review:
+    enabled: false


### PR DESCRIPTION
Disable CodeRabbit auto-review, as it's eating up credits even when the PR is not ready (Draft). 

Note: _Also reported this to CodeRabbit support._

Actually, the current per-account (organization) global settings already disable all of these features:

```yaml
# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
reviews:
  request_changes_workflow: true
  review_details: true
  poem: true
  auto_review:
    enabled: false
    auto_incremental_review: false
  finishing_touches:
    unit_tests:
      enabled: false
```
- https://app.coderabbit.ai/organization/settings/general

But auto-review was still fired:
- https://github.com/glensc/python-pytrakt/pull/121#issuecomment-4924005365
- https://github.com/glensc/python-pytrakt/pull/122#issuecomment-4924043859 (this pr)