### PR TITLE
Refactor: Re-use build_movies for watchlist_movies

### DIFF
--- a/trakt/users.py
+++ b/trakt/users.py
@@ -511,12 +511,12 @@ class User:
         :param data: List of raw movie dicts from the Trakt API
         :return: List of :class:`Movie` instances
         """
-        watched_movies = []
+        movies = []
         for movie in data:
             movie_data = movie.pop('movie')
             movie_data.update(movie)
-            watched_movies.append(Movie(**movie_data))
-        return watched_movies
+            movies.append(Movie(**movie_data))
+        return movies
 
     @get
     def get_watched_movies(self, page=None, limit=None):

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -457,11 +457,7 @@ class User:
             data = paginate('users/{username}/watchlist/movies',
                 username=slugify(self.username),
             )
-            self._movie_watchlist = []
-            for movie in data:
-                mov = movie.pop('movie')
-                mov.update(movie)
-                self._movie_watchlist.append(Movie(**mov))
+            self._movie_watchlist = self._build_movies(data or [])
         return self._movie_watchlist
 
     @property


### PR DESCRIPTION
Address coderabbit review nit-pick:
> `452-465`: _:triangular_ruler: Maintainability & Code Quality_ | _:large_blue_circle: Trivial_ | _:zap: Quick win_
>
> **Reuse `_build_movies` in `watchlist_movies` to avoid duplication.**
>
> The inline movie-building loop at lines 460-464 is identical to the logic in `_build_movies` (lines 518-523), which was extracted in this PR specifically to eliminate duplication. `watchlist_movies` should reuse the same helper for consistency.

- https://github.com/glensc/python-pytrakt/pull/123#pullrequestreview-4664447266