### PR TITLE
Fix: Handle invalid data in build_movies

### DIFF
--- a/trakt/users.py
+++ b/trakt/users.py
@@ -524,11 +524,19 @@ class User:
         :param data: List of raw movie dicts from the Trakt API
         :return: List of :class:`Movie` instances
         """
+
         movies = []
         for movie in data:
             movie_data = movie.pop('movie')
+            # Title is required for Movie model
+            if movie_data.get('title') is None:
+                original = dict(**movie, **{'movie': movie_data})
+                logger.warning("Ignoring invalid Movie with no title: %s", original)
+                continue
+
             movie_data.update(movie)
             movies.append(Movie(**movie_data))
+
         return movies
 
     @get

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Interfaces to all of the User objects offered by the Trakt.tv API"""
 
+import logging
 from dataclasses import dataclass, fields
 from typing import Any, NamedTuple, Optional, Union
 
@@ -16,6 +17,7 @@ __author__ = 'Jon Nappi'
 __all__ = ['User', 'UserList', 'PublicList', 'Request', 'follow', 'get_all_requests',
            'get_user_settings', 'unfollow']
 
+logger = logging.getLogger(__name__)
 
 class Request(NamedTuple):
     id: int


### PR DESCRIPTION
`/users/me/collection/movies?extended=metadata` endpoint seems to be buggy:
1. contains entries that appear empty: `{'type': 'movie', 'collected_at': '2016-11-21T15:55:31.000Z', 'updated_at': '2019-02-03T16:31:47.000Z', 'available_on': [], 'metadata': None, 'movie': {'ids': {'imdb': None, 'plex': {'guid': None, 'slug': None}, 'slug': None, 'tmdb': None, 'trakt':  None}, 'year': None, 'title': None}}`
2. Wrong pagination info: headers have `x-pagination-page-count: 156`, but page 30 is already empty

This adds a workaround the first problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of movie results with missing titles by skipping invalid entries.
  * Added warning logs when incomplete movie data is encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->